### PR TITLE
Potential fix for code scanning alert no. 55: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -70,11 +70,10 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
 
-    // TODO fix me disabled for now.
-    if (securityEnabled) {
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Compliant
-      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // compliant
-    }
+    // Secure XMLInputFactory against XXE attacks
+    xif.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTDs entirely
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow external DTDs
+    xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 


### PR DESCRIPTION
Potential fix for [https://github.com/Endrimaskaj/WebGoat/security/code-scanning/55](https://github.com/Endrimaskaj/WebGoat/security/code-scanning/55)

To fix the XXE vulnerability, the XML parser must be securely configured to prevent external entity expansion and DTD processing, regardless of the `securityEnabled` flag. The best approach is to always set the relevant security properties on the `XMLInputFactory` before parsing any user-supplied XML. Specifically, set the following properties:

- `XMLInputFactory.SUPPORT_DTD` to `false` (disables DTDs entirely)
- `XMLConstants.ACCESS_EXTERNAL_DTD` to `""` (disables external DTDs)
- `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to `""` (disables external schemas)

These settings should be applied unconditionally, or at least whenever untrusted input is parsed. In this case, since the method is used for parsing user input, the safest fix is to always apply these settings, removing the conditional on `securityEnabled`. This change should be made in the `parseXml` method in `CommentsCache.java`.

No new dependencies are required, as all used classes are from the JDK or Jakarta EE.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
