### PR TITLE
Potential fix for code scanning alert no. 60: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/BlindSendFileAssignment.java
@@ -76,7 +76,7 @@ public class BlindSendFileAssignment implements AssignmentEndpoint, Initializabl
     }
 
     try {
-      Comment comment = comments.parseXml(commentStr, false);
+      Comment comment = comments.parseXml(commentStr);
       if (fileContentsForUser.contains(comment.getText())) {
         comment.setText("Nice try, you need to send the file to WebWolf");
       }

--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -65,43 +65,38 @@ public class CommentsCache {
    * progress etc). In real life the XmlMapper bean defined above will be used automatically and the
    * Comment class can be directly used in the controller method (instead of a String)
    */
-  protected Comment parseXml(String xml, boolean securityEnabled)
+  protected Comment parseXml(String xml)
       throws XMLStreamException, JAXBException {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
-
-    if (securityEnabled) {
-      try {
-        xif.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTDs entirely
-      } catch (IllegalArgumentException e) {
-        throw new XMLStreamException("Failed to disable DTD support on XMLInputFactory", e);
-      }
-      try {
-        xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow external DTDs
-      } catch (IllegalArgumentException e) {
-        throw new XMLStreamException("Failed to disallow external DTDs on XMLInputFactory", e);
-      }
-      try {
-        xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
-      } catch (IllegalArgumentException e) {
-        throw new XMLStreamException("Failed to disallow external schemas on XMLInputFactory", e);
-      }
+    try {
+      xif.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTDs entirely
+    } catch (IllegalArgumentException e) {
+      throw new XMLStreamException("Failed to disable DTD support on XMLInputFactory", e);
+    }
+    try {
+      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow external DTDs
+    } catch (IllegalArgumentException e) {
+      throw new XMLStreamException("Failed to disallow external DTDs on XMLInputFactory", e);
+    }
+    try {
+      xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
+    } catch (IllegalArgumentException e) {
+      throw new XMLStreamException("Failed to disallow external schemas on XMLInputFactory", e);
     }
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));
 
     var unmarshaller = jc.createUnmarshaller();
-    if (securityEnabled) {
-      try {
-        unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-      } catch (Exception e) {
-        throw new JAXBException("Failed to disallow external DTDs on Unmarshaller", e);
-      }
-      try {
-        unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-      } catch (Exception e) {
-        throw new JAXBException("Failed to disallow external schemas on Unmarshaller", e);
-      }
+    try {
+      unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    } catch (Exception e) {
+      throw new JAXBException("Failed to disallow external DTDs on Unmarshaller", e);
+    }
+    try {
+      unmarshaller.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    } catch (Exception e) {
+      throw new JAXBException("Failed to disallow external schemas on Unmarshaller", e);
     }
     return (Comment) unmarshaller.unmarshal(xsr);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Endrimaskaj/WebGoat/security/code-scanning/60](https://github.com/Endrimaskaj/WebGoat/security/code-scanning/60)

To fix the XXE vulnerability, the code must always disable DTDs and external entity resolution when parsing untrusted XML, regardless of the `securityEnabled` flag. The best way to do this is to remove the `securityEnabled` parameter and always apply the secure configuration to the XML parser and unmarshaller. This involves:

- Removing the `securityEnabled` parameter from `parseXml` and all its call sites.
- Always setting the following properties on `XMLInputFactory`:
  - `XMLInputFactory.SUPPORT_DTD` to `false`
  - `XMLConstants.ACCESS_EXTERNAL_DTD` to `""`
  - `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to `""`
- Always setting the following properties on the JAXB `Unmarshaller`:
  - `XMLConstants.ACCESS_EXTERNAL_DTD` to `""`
  - `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to `""`
- Updating all calls to `parseXml` to remove the `securityEnabled` argument.

All changes are limited to the code shown in `CommentsCache.java` and `BlindSendFileAssignment.java`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
