### PR TITLE
Potential fix for code scanning alert no. 61: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
+++ b/src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java
@@ -70,19 +70,14 @@ public class CommentsCache {
     var jc = JAXBContext.newInstance(Comment.class);
     var xif = XMLInputFactory.newInstance();
     try {
+      // Disable DTDs and external entities for StAX
       xif.setProperty(XMLInputFactory.SUPPORT_DTD, false); // Disable DTDs entirely
-    } catch (IllegalArgumentException e) {
-      throw new XMLStreamException("Failed to disable DTD support on XMLInputFactory", e);
-    }
-    try {
+      xif.setProperty("javax.xml.stream.isSupportingExternalEntities", false); // Disable external entities
+      xif.setProperty("javax.xml.stream.supportDTD", false); // Disable DTDs
       xif.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ""); // Disallow external DTDs
-    } catch (IllegalArgumentException e) {
-      throw new XMLStreamException("Failed to disallow external DTDs on XMLInputFactory", e);
-    }
-    try {
       xif.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ""); // Disallow external schemas
     } catch (IllegalArgumentException e) {
-      throw new XMLStreamException("Failed to disallow external schemas on XMLInputFactory", e);
+      throw new XMLStreamException("Failed to securely configure XMLInputFactory against XXE", e);
     }
 
     var xsr = xif.createXMLStreamReader(new StringReader(xml));


### PR DESCRIPTION
Potential fix for [https://github.com/Endrimaskaj/WebGoat/security/code-scanning/61](https://github.com/Endrimaskaj/WebGoat/security/code-scanning/61)

To fully mitigate XXE risks, the code should explicitly disable DTDs and external entity resolution on all XML parsers involved. For StAX (`XMLInputFactory`), the code should set the `"javax.xml.stream.isSupportingExternalEntities"` property to `false` and the `"javax.xml.stream.supportDTD"` property to `false`. For JAXB (`Unmarshaller`), the code should set `XMLConstants.ACCESS_EXTERNAL_DTD` and `XMLConstants.ACCESS_EXTERNAL_SCHEMA` to empty strings. Additionally, the code should fail securely if any property cannot be set, rather than continuing. The most robust fix is to set all relevant properties and features, and to throw an exception if any property cannot be set. The changes should be made in the `parseXml` method in `src/main/java/org/owasp/webgoat/lessons/xxe/CommentsCache.java`, specifically in the block where the XML parser is configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
